### PR TITLE
Does not run rm if no files need to be removed

### DIFF
--- a/dovecot_backup.sh
+++ b/dovecot_backup.sh
@@ -329,6 +329,7 @@ for users in `doveadm user "*"`; do
                 log "Packaging to archive for user: $users ..."
                 $TAR_COMMAND -cvzf $users-$FILE_BACKUP $USERPART --atime-preserve --preserve-permissions
 		chown $MAILDIR_USER:$MAILDIR_GROUP $users-$FILE_BACKUP
+                chmod 600 $users-$FILE_BACKUP
 
                 log "Delete archive files for user: $users ..."
                 (ls $users-$FILE_DELETE -t|head -n $BACKUPFILES_DELETE;ls $users-$FILE_DELETE )|sort|uniq -u|xargs -r rm

--- a/dovecot_backup.sh
+++ b/dovecot_backup.sh
@@ -330,7 +330,7 @@ for users in `doveadm user "*"`; do
                 $TAR_COMMAND -cvzf $users-$FILE_BACKUP $USERPART --atime-preserve --preserve-permissions
 
                 log "Delete archive files for user: $users ..."
-                (ls $users-$FILE_DELETE -t|head -n $BACKUPFILES_DELETE;ls $users-$FILE_DELETE )|sort|uniq -u|xargs rm
+                (ls $users-$FILE_DELETE -t|head -n $BACKUPFILES_DELETE;ls $users-$FILE_DELETE )|sort|uniq -u|xargs -r rm
                 if [ "$?" != "0" ]; then
                         log "Delete old archive files $DIR_BACKUP .....................[FAILED]"
                 else

--- a/dovecot_backup.sh
+++ b/dovecot_backup.sh
@@ -328,6 +328,7 @@ for users in `doveadm user "*"`; do
 
                 log "Packaging to archive for user: $users ..."
                 $TAR_COMMAND -cvzf $users-$FILE_BACKUP $USERPART --atime-preserve --preserve-permissions
+		chown $MAILDIR_USER:$MAILDIR_GROUP $users-$FILE_BACKUP
 
                 log "Delete archive files for user: $users ..."
                 (ls $users-$FILE_DELETE -t|head -n $BACKUPFILES_DELETE;ls $users-$FILE_DELETE )|sort|uniq -u|xargs -r rm


### PR DESCRIPTION
Fixes error where xargs attempts to run rm with no operands when there exists less than $BACKUPFILES_DELETE .